### PR TITLE
Extended header and footer to be the whole width of the page

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -2,7 +2,7 @@ body {
   font-family: 'Montserrat', sans-serif;
 }
 
-#content {
+#intro-sec, #education-sec, #project-sec, #gallery-sec {
   width: 1100px;
   margin: auto;
   background-color: white;
@@ -49,8 +49,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 footer {
+  width: 100%;
   padding: 3px;
   background-color: teal;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .unindentedlist {
@@ -110,6 +114,7 @@ button {
 }
 
 header {
+  width: 100%;
   height: 50px;
   padding: 3px;
   background-color: teal;
@@ -242,6 +247,6 @@ p {
   height: 20px;
   border-radius: 50%;
   position: absolute;
-  left: 35.6%;
+  left: 35.1%;
   background-color: teal;
 }


### PR DESCRIPTION
In this pull request I extended the header and the footer so that they were as wide as the page rather than as wide as the content section.
![image](https://user-images.githubusercontent.com/22436066/83313792-85e50300-a1cc-11ea-8f37-8798cf92c6f7.png)
