### PR TITLE
Change query mechanism, separate comment section onto new page

### DIFF
--- a/portfolio/index.yaml
+++ b/portfolio/index.yaml
@@ -3,14 +3,14 @@ indexes:
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: time
     direction: desc
 
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: name
     direction: desc
 
@@ -18,27 +18,27 @@ indexes:
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: email
     direction: desc
 
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: time
     direction: asc
 
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: name
     direction: asc
 
 - kind: Comment
   ancestor: no
   properties:
-  - name: parentid
+  - name: rootid
   - name: email
     direction: asc

--- a/portfolio/index.yaml
+++ b/portfolio/index.yaml
@@ -1,0 +1,44 @@
+indexes:
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: time
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: name
+    direction: desc
+
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: email
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: time
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: name
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: parentid
+  - name: email
+    direction: asc

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -51,7 +51,7 @@ public class DataServlet extends HttpServlet {
     String sortOrder = UtilityFunctions.getFieldFromResponse(request, "order", "desc");
 
     ArrayList<UserComment> comments = new ArrayList<>();
-    comments = populateRootComments(comments, maxComments, sortOrder, sortMetric);
+    populateRootComments(comments, maxComments, sortOrder, sortMetric);
 
     Gson gson = new Gson();
     response.setContentType("application/json;");
@@ -62,7 +62,7 @@ public class DataServlet extends HttpServlet {
    * Returns a list containing atmost maxComments top-level queries and all their replies. 
    * The top-level queries are sorted by sortMetric in sortOrder
    */ 
-  private ArrayList<UserComment> populateRootComments(ArrayList<UserComment> comments, int maxComments, String sortOrder, String sortMetric) {
+  private void populateRootComments(ArrayList<UserComment> comments, int maxComments, String sortOrder, String sortMetric) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     Builder builder = Query.newEntityQueryBuilder();
     builder = builder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", 0));
@@ -81,13 +81,12 @@ public class DataServlet extends HttpServlet {
       Entity entity = results.next();
       UserComment comment = entityToComment(entity);
       comments.add(comment);
-      comments = populateChildComments(comments, entity.getKey().getId());
+      populateChildComments(comments, entity.getKey().getId());
     }
-    return comments;
   }
 
   // Returns a list containing all replies of the comment with ID rootId 
-  private ArrayList<UserComment> populateChildComments(ArrayList<UserComment> comments, long rootId) {
+  private void populateChildComments(ArrayList<UserComment> comments, long rootId) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     Builder builder = Query.newEntityQueryBuilder();
     builder = builder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", rootId));
@@ -99,7 +98,6 @@ public class DataServlet extends HttpServlet {
       UserComment comment = entityToComment(entity);
       comments.add(comment);
     }
-    return comments;
   }
 
   // Creates a UserComment object from the given entity

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -62,16 +62,8 @@ public class DataServlet extends HttpServlet {
 
     ArrayList<UserComment> comments = new ArrayList<>();
     while (results.hasNext()) {
-
       Entity entity = results.next();
-      long id = entity.getKey().getId();
-      String name = entity.getString("name");
-      String email = entity.getString("email");
-      long time =  entity.getLong("time");
-      String comment = entity.getString("comment");
-      long parentId = entity.getLong("parentid");
-      long rootId = entity.getLong("rootid");
-      UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId);
+      UserComment userComment = entityToComment(entity);
       comments.add(userComment);
       Builder childBuilder = Query.newEntityQueryBuilder();
       childBuilder = childBuilder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", id));
@@ -90,6 +82,19 @@ public class DataServlet extends HttpServlet {
     response.setContentType("application/json;");
     response.getWriter().println(gson.toJson(comments));
   }
+
+  private UserComment entityToComment(Entity entity) {
+    long id = entity.getKey().getId();
+    String name = entity.getString("name");
+    String email = entity.getString("email");
+    long time =  entity.getLong("time");
+    String comment = entity.getString("comment");
+    long parentId = entity.getLong("parentid");
+    long rootId = entity.getLong("rootid");
+    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId);
+    return userComment;
+  }
+
 
   /*
    * Called when a client submits a POST request to the /data URL

--- a/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
@@ -47,7 +47,8 @@ public class ReplyServlet extends HttpServlet {
       String currDate = String.valueOf(System.currentTimeMillis());
       long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "timestamp", currDate));
       long parentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "parentid", "0"));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId, true);
+      long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "rootid", "0"));
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId, rootId, true);
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
@@ -18,8 +18,8 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue 
 abstract class UserComment {
-  static UserComment create(String name, String email, String comment, long timestamp, long id, long parentId) {
-    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId);
+  static UserComment create(String name, String email, String comment, long timestamp, long id, long parentId, long rootId) {
+    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId, rootId);
   }
 
   /*
@@ -70,4 +70,13 @@ abstract class UserComment {
    * Invariants: Always non-negative
    */
   abstract long parentId();
+
+  /*
+   * Represents the ID of the root of the comment tree that 
+   * this reply is part of. If this is the root, rootId is
+   * 0. 
+   * Default Value: -
+   * Invariants: Always non-negative
+   */
+  abstract long rootId();
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
@@ -37,8 +37,8 @@ public class UtilityFunctions {
   }
 
   // Adds a comment with the given metadata to the database  
-  public static void addToDatastore(String name, String email, long dateTime, String comment, long parentId, boolean isReply) {
-    if (isReply && (parentId == 0)) {
+  public static void addToDatastore(String name, String email, long dateTime, String comment, long parentId, long rootId, boolean isReply) {
+    if ((isReply && (parentId == 0)) || (isReply && (rootId == 0))) {
         return;
     }
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
@@ -51,6 +51,7 @@ public class UtilityFunctions {
           .set("time", dateTime)
           .set("comment", comment)
           .set("parentid", parentId)
+          .set("rootid", rootId)
           .build();
     datastore.add(thisComment);
   }

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Ishani Santurkar</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script src="script.js"></script>
+</head>
+
+<body id="content" onload="loadComments()">
+  <header>
+    <a class="headerelem" href="index.html">About Me</a>
+    <a class="headerelem" href="education.html">Education</a>
+    <a class="headerelem" href="projects.html">Projects</a>
+    <a class="headerelem" href="gallery.html">Gallery</a>
+    <a class="headerelem current" href="comments.html">Comments</a>
+  </header>
+  <section id="comment-sec">
+    <h1>Comments</h1>
+    I'm still in the process of building this website and would love your feedback on it!
+    <div id="commentform">
+      <h2>Submit a new comment</h2>
+      <form id="newcommentform" onsubmit="submitForm(this); return false">
+        <label for="user_name">Name:</label>
+        <br /><br />
+        <input type="text" id="user_name" name="name">
+        <br /><br />
+        <label for="user_email">Email ID:</label>
+        <br /><br />
+        <input type="email" id="user_email" name="email">
+        <br /><br />
+        <input type="hidden" id="user_time" name="timestamp">
+        <br /><br />
+        <label for="user_comment">Comment:</label>
+        <br /><br />
+        <textarea id="user_comment" name="comment" placeholder="Type your comment here"></textarea>
+        <br /><br />
+        <input type="submit">
+      </form>
+    </div>
+    <div id="commenthistory">
+      <h2>Comment History</h2>
+      <span class="commentparam">
+        <label for="numcomments">Displaying: </label>
+        <select name="numcomments" id="numcomments" onchange="loadComments()">
+          <option value="5">5</option>
+          <option value="10">10</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+        </select>
+      </span>
+      <span class="commentparam">
+        <label for="sortby">Sort By:</label>
+        <select name="sortby" id="sortby" onchange="loadComments()">
+          <option value="name">Author</option>
+          <option value="email">Email ID</option>
+          <option value="time" selected>Submission Time</option>
+        </select>
+        <button id="sortorder" class="desc material-icons" onclick="changeSortOrder()">arrow_drop_down</button>
+      </span>
+      <span class="commentparam">
+        <button onclick="clearComments()">Clear</button>
+      </span>
+      <ul id="toplevelcomments" class="comments"></ul>
+    </div>
+  </section>
+  <footer>
+    <a href="https://www.linkedin.com/in/ishani-s-126b27143/"><img src="/images/linkedin.jpg" class="footerelem"></a>
+    <a href="http://github.com/IshaniSanturkar"><img src="/images/github.png" class="footerelem"></a>
+    <a href="mailto:ishani.santurkar@gmail.com"><img src="/images/gmail.png" class="footerelem"></a>
+    <a href="tel:+16692729041"><img src="/images/phone.png" class="footerelem"></a>
+  </footer>
+</body>
+
+</html>

--- a/portfolio/src/main/webapp/education.html
+++ b/portfolio/src/main/webapp/education.html
@@ -15,6 +15,7 @@
     <a class="headerelem current" href="education.html">Education</a>
     <a class="headerelem" href="projects.html">Projects</a>
     <a class="headerelem" href="gallery.html">Gallery</a>
+    <a class="headerelem" href="comments.html">Comments</a>
   </header>
   <section id="education-sec">
     <h1>Education</h1>

--- a/portfolio/src/main/webapp/gallery.html
+++ b/portfolio/src/main/webapp/gallery.html
@@ -10,12 +10,13 @@
   <script src="script.js"></script>
 </head>
 
-<body id="content">
+<body id="content" onload="startSlideshow()">
   <header>
     <a class="headerelem" href="index.html">About Me</a>
     <a class="headerelem" href="education.html">Education</a>
     <a class="headerelem" href="projects.html">Projects</a>
     <a class="headerelem current" href="gallery.html">Gallery</a>
+    <a class="headerelem" href="comments.html">Comments</a>
   </header>
   <section id="gallery-sec">
     <h1>Gallery</h1>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -17,6 +17,7 @@
     <a class="headerelem" href="education.html">Education</a>
     <a class="headerelem" href="projects.html">Projects</a>
     <a class="headerelem" href="gallery.html">Gallery</a>
+    <a class="headerelem" href="comments.html">Comments</a>
   </header>
   <section id="intro-sec">
     <h1>About Me</h1>
@@ -36,57 +37,6 @@
         especially Hindi music. Recently, I got into Bollywood Dance and I'm working on getting better at it.
         My dad is a software engineer at SAP while my mom is a part-time teacher. My older sister Shibani is a PhD
         student at MIT. Click <a href="gallery.html">here</a> to see photos of my life!</p>
-    </div>
-  </section>
-  <section id="comment-sec">
-    <h2>Comments</h2>
-    I'm still in the process of building this website and would love your feedback on it!
-    <div class="row">
-      <div class="column" id="commentform">
-        <h3>Submit a new comment</h3>
-        <form id="newcommentform" onsubmit="submitForm(this); return false">
-          <label for="user_name">Name:</label>
-          <br /><br />
-          <input type="text" id="user_name" name="name">
-          <br /><br />
-          <label for="user_email">Email ID:</label>
-          <br /><br />
-          <input type="email" id="user_email" name="email">
-          <br /><br />
-          <input type="hidden" id="user_time" name="timestamp">
-          <br /><br />
-          <label for="user_comment">Comment:</label>
-          <br /><br />
-          <textarea id="user_comment" name="comment" placeholder="Type your comment here"></textarea>
-          <br /><br />
-          <input type="submit">
-        </form>
-      </div>
-      <div class="column" id="commenthistory">
-        <h3>Comment History</h3>
-        <span class="commentparam">
-          <label for="numcomments">Displaying: </label>
-          <select name="numcomments" id="numcomments" onchange="loadComments()">
-            <option value="5">5</option>
-            <option value="10">10</option>
-            <option value="15">15</option>
-            <option value="20">20</option>
-          </select>
-        </span>
-        <span class="commentparam">
-          <label for="sortby">Sort By:</label>
-          <select name="sortby" id="sortby" onchange="loadComments()">
-            <option value="name">Author</option>
-            <option value="email">Email ID</option>
-            <option value="time" selected>Submission Time</option>
-          </select>
-          <button id="sortorder" class="desc material-icons" onclick="changeSortOrder()">arrow_drop_down</button>
-        </span>
-        <span class="commentparam">
-          <button onclick="clearComments()">Clear</button>
-        </span>
-        <ul id="toplevelcomments" class="comments"></ul>
-      </div>
     </div>
   </section>
   <footer>

--- a/portfolio/src/main/webapp/projects.html
+++ b/portfolio/src/main/webapp/projects.html
@@ -15,6 +15,7 @@
     <a class="headerelem" href="education.html">Education</a>
     <a class="headerelem current" href="projects.html">Projects</a>
     <a class="headerelem" href="gallery.html">Gallery</a>
+    <a class="headerelem" href="comments.html">Comments</a>
   </header>
   <section id="project-sec">
     <h1>Projects and Experiences</h1>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -134,14 +134,14 @@ function loadComments() {
       commentList.removeChild(commentList.lastChild);
     }
     const commentTree = locateChildren(comments);
-    let numDisplayed = 0;
+    // let numDisplayed = 0;
     for (commentId in commentTree) {
-      if (numDisplayed == maxcomments) {
-        break;
-      }
+    //   if (numDisplayed == maxcomments) {
+    //     break;
+    //   }
       let comment = commentTree[commentId];
       if (comment["parentId"] === 0) {
-        numDisplayed++;
+        // numDisplayed++;
         commentList.appendChild(constructReplyTree(comment, commentTree, 40));
       }
     }
@@ -256,6 +256,7 @@ function replyTo(comment) {
   const replyObj = {};
   replyObj["comment"] = replyContent;
   replyObj["parentid"] = comment["id"];
+  replyObj["rootid"] = (comment["rootId"] === 0) ? comment["id"] : comment["rootId"];
   fetch('/reply', {
     method: 'POST',
     headers: {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -15,7 +15,7 @@
 const loc = "/images/life/";
 let currImageNum = 1;
 let sliderSpeed = 5000;
-let myTimer = setInterval(loopOverImages, sliderSpeed);
+let myTimer;
 let paused = false;
 
 // Shows or hides the list of courses for a particular semester upon user click
@@ -113,6 +113,11 @@ function togglePause() {
   }
 }
 
+// Initiates slideshow transition loop when gallery page loads
+function startSlideshow() {
+  myTimer = setInterval(loopOverImages, sliderSpeed);
+}
+
 /**
  * Retrieves parameters related to comment ordering and display,
  * submits a GET request to /data, receives the response
@@ -134,14 +139,9 @@ function loadComments() {
       commentList.removeChild(commentList.lastChild);
     }
     const commentTree = locateChildren(comments);
-    // let numDisplayed = 0;
     for (commentId in commentTree) {
-    //   if (numDisplayed == maxcomments) {
-    //     break;
-    //   }
       let comment = commentTree[commentId];
       if (comment["parentId"] === 0) {
-        // numDisplayed++;
         commentList.appendChild(constructReplyTree(comment, commentTree, 40));
       }
     }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -127,7 +127,7 @@ header {
   color: white;
   text-decoration: none;
   font-size: 20px;
-  min-width: 248px;
+  min-width: 278px;
 }
 
 .current {
@@ -260,35 +260,29 @@ p {
 }
 
 #toplevelcomments {
-  max-height: 400px;
+  height: 800px;
   overflow: auto;
   background-color: white;
   overflow-x: scroll;
+  padding-bottom: 20px;
+  margin-left: 20px;
+  margin-right:20px;
 }
 
 .comments {
   list-style-type: none;
   margin-top: 20px;
-  margin-bottom: 20px;
-  margin-right: 20px;
-  min-width: 600px;
 }
 
 .comment {
+  min-width: 600px;
   min-height: 30px;
   background-color: rgb(166, 166, 166);
+  margin-right: 20px;
 }
 
 .comment_metadata {
   font-size: 15px;
-}
-
-#commentform {
-  width: 40%;
-}
-
-#commenthistory {
-  width:60%;
 }
 
 #sortorder {


### PR DESCRIPTION
In this PR I:
- changed the code so that limiting the number of queries displayed was carried out on the server side by adding a query parameter rather than on the client side
- moved the comments section to its own page and added a header section for it

The page now looks like this: [portfoliov8.zip](https://github.com/IshaniSanturkar/step/files/4737599/portfoliov8.zip)
