### PR TITLE
Add ability to filter by content of fields and toggle reply trees

### DIFF
--- a/portfolio/index.yaml
+++ b/portfolio/index.yaml
@@ -55,3 +55,171 @@ indexes:
   - name: rootid
   - name: score
     direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: time
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: name
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: email
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: score
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: time
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: name
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: email
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: name
+  - name: score
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: time
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: name
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: email
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: rootid
+  - name: score
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: time
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: name
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: email
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: email
+  - name: score
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: time
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: name
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: email
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: score
+    direction: desc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: time
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: name
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: email
+    direction: asc
+
+- kind: Comment
+  ancestor: no
+  properties:
+  - name: comment
+  - name: score
+    direction: asc

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -145,8 +145,9 @@ public class DataServlet extends HttpServlet {
       String currDate = String.valueOf(System.currentTimeMillis());
       long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
           , "timestamp", currDate));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, 0, 0, false
-          , 0, 0);
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment
+          , /* parentId = */ 0, /* rootId = */ 0, /* isReply = */ false
+              , /* upvotes = */ 0, /* downvotes = */ 0);
 
     }
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -49,9 +49,11 @@ public class DataServlet extends HttpServlet {
     int maxComments = Integer.parseInt(UtilityFunctions.getFieldFromResponse(request, "maxcomments", defaultMaxComment));
     String sortMetric = UtilityFunctions.getFieldFromResponse(request, "metric", "time");
     String sortOrder = UtilityFunctions.getFieldFromResponse(request, "order", "desc");
+    String filterMetric = UtilityFunctions.getFieldFromResponse(request, "filterby", "comment");
+    String filterText = UtilityFunctions.getFieldFromResponse(request, "filtertext", "");
 
     ArrayList<UserComment> comments = new ArrayList<>();
-    populateRootComments(comments, maxComments, sortOrder, sortMetric);
+    populateRootComments(comments, maxComments, sortOrder, sortMetric, filterMetric, filterText);
 
     Gson gson = new Gson();
     response.setContentType("application/json;");
@@ -62,7 +64,7 @@ public class DataServlet extends HttpServlet {
    * Returns a list containing atmost maxComments top-level queries and all their replies. 
    * The top-level queries are sorted by sortMetric in sortOrder
    */ 
-  private void populateRootComments(ArrayList<UserComment> comments, int maxComments, String sortOrder, String sortMetric) {
+  private void populateRootComments(ArrayList<UserComment> comments, int maxComments, String sortOrder, String sortMetric, String filterMetric, String filterText) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     Builder builder = Query.newEntityQueryBuilder();
     builder = builder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", 0));
@@ -71,6 +73,10 @@ public class DataServlet extends HttpServlet {
       builder = builder.setOrderBy(StructuredQuery.OrderBy.desc(sortMetric));
     } else {
       builder = builder.setOrderBy(StructuredQuery.OrderBy.asc(sortMetric));
+    }
+
+    if (filterText.length() != 0) {
+        builder = builder.setFilter(PropertyFilter.eq(filterMetric, filterText));
     }
     
     builder = builder.setLimit(maxComments);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -46,7 +46,8 @@ public class DataServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int maxComments = Integer.parseInt(UtilityFunctions.getFieldFromResponse(request, "maxcomments", defaultMaxComment));
+    int maxComments = Integer.parseInt(UtilityFunctions.getFieldFromResponse(request, "maxcomments"
+        , defaultMaxComment));
     String sortMetric = UtilityFunctions.getFieldFromResponse(request, "metric", "time");
     String sortOrder = UtilityFunctions.getFieldFromResponse(request, "order", "desc");
     String filterMetric = UtilityFunctions.getFieldFromResponse(request, "filterby", "comment");
@@ -64,7 +65,8 @@ public class DataServlet extends HttpServlet {
    * Returns a list containing atmost maxComments top-level queries and all their replies. 
    * The top-level queries are sorted by sortMetric in sortOrder
    */ 
-  private void populateRootComments(ArrayList<UserComment> comments, int maxComments, String sortOrder, String sortMetric, String filterMetric, String filterText) {
+  private void populateRootComments(ArrayList<UserComment> comments, int maxComments
+        , String sortOrder, String sortMetric, String filterMetric, String filterText) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     Builder builder = Query.newEntityQueryBuilder();
     builder = builder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", 0));
@@ -117,7 +119,8 @@ public class DataServlet extends HttpServlet {
     long rootId = entity.getLong("rootid");
     long upvotes = entity.getLong("upvotes");
     long downvotes = upvotes - entity.getLong("score");
-    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId, upvotes, downvotes);
+    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId
+        , upvotes, downvotes);
     return userComment;
   }
 
@@ -137,10 +140,13 @@ public class DataServlet extends HttpServlet {
     String userComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
     if (userComment.length() != 0) {
       String userName = UtilityFunctions.getFieldFromJsonObject(jsonObject, "name", "Anonymous");
-      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email", "janedoe@gmail.com");
+      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email"
+          , "janedoe@gmail.com");
       String currDate = String.valueOf(System.currentTimeMillis());
-      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "timestamp", currDate));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, 0, 0, false, 0, 0);
+      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
+          , "timestamp", currDate));
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, 0, 0, false
+          , 0, 0);
 
     }
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -46,8 +46,8 @@ public class DataServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int maxComments = Integer.parseInt(UtilityFunctions.getFieldFromResponse(request, "maxcomments"
-        , defaultMaxComment));
+    int maxComments = Integer.parseInt(UtilityFunctions.getFieldFromResponse(
+        request, "maxcomments", defaultMaxComment));
     String sortMetric = UtilityFunctions.getFieldFromResponse(request, "metric", "time");
     String sortOrder = UtilityFunctions.getFieldFromResponse(request, "order", "desc");
     String filterMetric = UtilityFunctions.getFieldFromResponse(request, "filterby", "comment");
@@ -65,8 +65,13 @@ public class DataServlet extends HttpServlet {
    * Returns a list containing atmost maxComments top-level queries and all their replies. 
    * The top-level queries are sorted by sortMetric in sortOrder
    */ 
-  private void populateRootComments(ArrayList<UserComment> comments, int maxComments
-        , String sortOrder, String sortMetric, String filterMetric, String filterText) {
+  private void populateRootComments(
+      ArrayList<UserComment> comments,
+      int maxComments,
+      String sortOrder,
+      String sortMetric,
+      String filterMetric,
+      String filterText) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     Builder builder = Query.newEntityQueryBuilder();
     builder = builder.setKind("Comment").setFilter(PropertyFilter.eq("rootid", 0));

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -124,8 +124,8 @@ public class DataServlet extends HttpServlet {
     long rootId = entity.getLong("rootid");
     long upvotes = entity.getLong("upvotes");
     long downvotes = upvotes - entity.getLong("score");
-    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId
-        , upvotes, downvotes);
+    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId,
+        upvotes, downvotes);
     return userComment;
   }
 
@@ -145,14 +145,14 @@ public class DataServlet extends HttpServlet {
     String userComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
     if (userComment.length() != 0) {
       String userName = UtilityFunctions.getFieldFromJsonObject(jsonObject, "name", "Anonymous");
-      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email"
-          , "janedoe@gmail.com");
+      String userEmail = UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "email", "janedoe@gmail.com");
       String currDate = String.valueOf(System.currentTimeMillis());
-      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
-          , "timestamp", currDate));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment
-          , /* parentId = */ 0, /* rootId = */ 0, /* isReply = */ false
-              , /* upvotes = */ 0, /* downvotes = */ 0);
+      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "timestamp", currDate));
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment,
+          /* parentId = */ 0, /* rootId = */ 0, /* isReply = */ false, /* upvotes = */ 0,
+              /* downvotes = */ 0);
 
     }
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
@@ -43,12 +43,17 @@ public class ReplyServlet extends HttpServlet {
     String userComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
     if (userComment.length() != 0) {
       String userName = UtilityFunctions.getFieldFromJsonObject(jsonObject, "name", "Anonymous");
-      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email", "janedoe@gmail.com");
+      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email"
+          , "janedoe@gmail.com");
       String currDate = String.valueOf(System.currentTimeMillis());
-      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "timestamp", currDate));
-      long parentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "parentid", "0"));
-      long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "rootid", "0"));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId, rootId, true, 0, 0);
+      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
+          , "timestamp", currDate));
+      long parentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
+          , "parentid", "0"));
+      long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
+          , "rootid", "0"));
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId
+          , rootId, true, 0, 0);
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
@@ -43,17 +43,17 @@ public class ReplyServlet extends HttpServlet {
     String userComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
     if (userComment.length() != 0) {
       String userName = UtilityFunctions.getFieldFromJsonObject(jsonObject, "name", "Anonymous");
-      String userEmail = UtilityFunctions.getFieldFromJsonObject(jsonObject, "email"
-          , "janedoe@gmail.com");
+      String userEmail = UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "email", "janedoe@gmail.com");
       String currDate = String.valueOf(System.currentTimeMillis());
-      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
-          , "timestamp", currDate));
-      long parentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
-          , "parentid", "0"));
-      long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
-          , "rootid", "0"));
-      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId
-          , rootId, /* isReply = */ true, /* upvotes = */ 0, /* downvotes = */ 0);
+      long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "timestamp", currDate));
+      long parentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "parentid", "0"));
+      long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "rootid", "0"));
+      UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId,
+          rootId, /* isReply = */ true, /* upvotes = */ 0, /* downvotes = */ 0);
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
@@ -53,7 +53,7 @@ public class ReplyServlet extends HttpServlet {
       long rootId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject
           , "rootid", "0"));
       UtilityFunctions.addToDatastore(userName, userEmail, userDate, userComment, parentId
-          , rootId, true, 0, 0);
+          , rootId, /* isReply = */ true, /* upvotes = */ 0, /* downvotes = */ 0);
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
@@ -18,8 +18,10 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue 
 abstract class UserComment {
-  static UserComment create(String name, String email, String comment, long timestamp, long id, long parentId, long rootId, long upvotes, long downvotes) {
-    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId, rootId, upvotes, downvotes);
+  static UserComment create(String name, String email, String comment, long timestamp
+      , long id, long parentId, long rootId, long upvotes, long downvotes) {
+    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId
+        , rootId, upvotes, downvotes);
   }
 
   /*

--- a/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
@@ -18,10 +18,18 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue 
 abstract class UserComment {
-  static UserComment create(String name, String email, String comment, long timestamp
-      , long id, long parentId, long rootId, long upvotes, long downvotes) {
-    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId
-        , rootId, upvotes, downvotes);
+  static UserComment create(
+      String name,
+      String email,
+      String comment,
+      long timestamp,
+      long id,
+      long parentId,
+      long rootId,
+      long upvotes,
+      long downvotes) {
+    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId,
+        rootId, upvotes, downvotes);
   }
 
   /*

--- a/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
@@ -28,8 +28,10 @@ public class UtilityFunctions {
    * Extracts the value of fieldName attribute from jsonObject if present
    * and returns defaultValue if it is not or the value is empty
    */
-  public static String getFieldFromJsonObject(JsonObject jsonObject, String fieldName
-        , String defaultValue) {
+  public static String getFieldFromJsonObject(
+      JsonObject jsonObject,
+      String fieldName,
+      String defaultValue) {
     if (jsonObject.has(fieldName)) {
       String fieldValue = jsonObject.get(fieldName).getAsString();
       return (fieldValue.length() == 0) ? defaultValue : fieldValue;
@@ -38,8 +40,16 @@ public class UtilityFunctions {
   }
 
   // Adds a comment with the given metadata to the database  
-  public static void addToDatastore(String name, String email, long dateTime, String comment
-        , long parentId, long rootId, boolean isReply, long upvotes, long downvotes) {
+  public static void addToDatastore(
+      String name,
+      String email,
+      long dateTime,
+      String comment,
+      long parentId,
+      long rootId,
+      boolean isReply,
+      long upvotes,
+      long downvotes) {
     if ((isReply && (parentId == 0)) || (isReply && (rootId == 0))) {
         return;
     }
@@ -64,8 +74,10 @@ public class UtilityFunctions {
    * Get value for fieldName for request if present. Return defaultValue if fieldName is not present
    * or the associated value is empty. Raise an exception if fieldName is mapped to multiple values.
    */
-  public static String getFieldFromResponse(HttpServletRequest request, String fieldName
-      , String defaultValue) {
+  public static String getFieldFromResponse(
+      HttpServletRequest request,
+      String fieldName,
+      String defaultValue) {
     String[] defaultArr = {defaultValue};
     String[] fieldValues = request.getParameterMap().getOrDefault(fieldName, defaultArr);
     if (fieldValues.length > 1) {

--- a/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
@@ -28,7 +28,8 @@ public class UtilityFunctions {
    * Extracts the value of fieldName attribute from jsonObject if present
    * and returns defaultValue if it is not or the value is empty
    */
-  public static String getFieldFromJsonObject(JsonObject jsonObject, String fieldName, String defaultValue) {
+  public static String getFieldFromJsonObject(JsonObject jsonObject, String fieldName
+        , String defaultValue) {
     if (jsonObject.has(fieldName)) {
       String fieldValue = jsonObject.get(fieldName).getAsString();
       return (fieldValue.length() == 0) ? defaultValue : fieldValue;
@@ -37,7 +38,8 @@ public class UtilityFunctions {
   }
 
   // Adds a comment with the given metadata to the database  
-  public static void addToDatastore(String name, String email, long dateTime, String comment, long parentId, long rootId, boolean isReply, long upvotes, long downvotes) {
+  public static void addToDatastore(String name, String email, long dateTime, String comment
+        , long parentId, long rootId, boolean isReply, long upvotes, long downvotes) {
     if ((isReply && (parentId == 0)) || (isReply && (rootId == 0))) {
         return;
     }
@@ -62,7 +64,8 @@ public class UtilityFunctions {
    * Get value for fieldName for request if present. Return defaultValue if fieldName is not present
    * or the associated value is empty. Raise an exception if fieldName is mapped to multiple values.
    */
-  public static String getFieldFromResponse(HttpServletRequest request, String fieldName, String defaultValue) {
+  public static String getFieldFromResponse(HttpServletRequest request, String fieldName
+      , String defaultValue) {
     String[] defaultArr = {defaultValue};
     String[] fieldValues = request.getParameterMap().getOrDefault(fieldName, defaultArr);
     if (fieldValues.length > 1) {

--- a/portfolio/src/main/java/com/google/sps/servlets/VoteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/VoteServlet.java
@@ -65,7 +65,8 @@ public class VoteServlet extends HttpServlet {
     long downvotes = upvotes - score;
     Entity updatedComment;
     if (isUpvote) {
-      updatedComment = Entity.newBuilder(comment).set("upvotes", upvotes + 1).set("score", score + 1).build();
+      updatedComment = Entity.newBuilder(comment).set("upvotes", upvotes + 1)
+          .set("score", score + 1).build();
     } else {
       updatedComment = Entity.newBuilder(comment).set("score", score - 1).build();
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/VoteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/VoteServlet.java
@@ -45,9 +45,11 @@ public class VoteServlet extends HttpServlet {
     JsonElement parsedJson = parser.parse(parsedBody);
     JsonObject jsonObject = parsedJson.getAsJsonObject();
 
-    long commentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(jsonObject, "id", "0"));
+    long commentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+        jsonObject, "id", "0"));
     if (commentId != 0) {
-      boolean isUpvote = Boolean.parseBoolean(UtilityFunctions.getFieldFromJsonObject(jsonObject, "isupvote", "true"));
+      boolean isUpvote = Boolean.parseBoolean(UtilityFunctions.getFieldFromJsonObject(
+          jsonObject, "isupvote", "true"));
       changeVoteInDatastore(commentId, isUpvote);
     }
   }

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -39,7 +39,7 @@
         <br /><br />
         <textarea id="user_comment" name="comment" placeholder="Type your comment here"></textarea>
         <br /><br />
-        <input type="submit">
+        <input type="submit" id="submitform">
       </form>
     </div>
     <div id="commenthistory">
@@ -66,6 +66,14 @@
       <span class="commentparam">
         <button onclick="clearComments()">Clear</button>
       </span>
+      <div id="filterdiv">
+        <select name="filterby" id="filterby" onchange="loadComments()">
+          <option value="name">Author</option>
+          <option value="email">Email ID</option>
+          <option value="comment" selected>Comment</option>
+        </select>
+        <input type="text" id="filtertext" placeholder="Filter Text" onchange="loadComments()">
+      </div>
       <ul id="toplevelcomments" class="comments"></ul>
     </div>
   </section>

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -67,6 +67,7 @@
         <button onclick="clearComments()">Clear</button>
       </span>
       <div id="filterdiv">
+        <label for="filterby">Filter By:</label>
         <select name="filterby" id="filterby" onchange="loadComments()">
           <option value="name">Author</option>
           <option value="email">Email ID</option>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -193,7 +193,7 @@ function constructReplyTree(comment, commentTree, margin) {
       replyTree.appendChild(subTree);
     }
     replyTree.style.marginLeft = `${margin}px`;
-    const toggleButton = createToggleButton();
+    const toggleButton = createToggleButton(replyTree);
     thisReply.appendChild(toggleButton);
     thisReply.appendChild(replyTree);
     return thisReply;
@@ -201,7 +201,7 @@ function constructReplyTree(comment, commentTree, margin) {
 }
 
 // Return button that toggles reply trees in and out
-function createToggleButton() {
+function createToggleButton(replyTree) {
   const toggleButton = document.createElement("button");
   toggleButton.classList.add("material-icons", "togglereply");
   toggleButton.innerText = "unfold_less";
@@ -214,6 +214,7 @@ function createToggleButton() {
       toggleButton.innerText = "unfold_more";
     }
   }
+  return toggleButton;
 }
 
 // Creates a list element with the given comment text and metadata (name, timestamp etc.)

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -193,21 +193,26 @@ function constructReplyTree(comment, commentTree, margin) {
       replyTree.appendChild(subTree);
     }
     replyTree.style.marginLeft = `${margin}px`;
-    const toggleButton = document.createElement("button");
-    toggleButton.classList.add("material-icons", "togglereply");
-    toggleButton.innerText = "unfold_less";
-    toggleButton.onclick = () => {
-      if (replyTree.classList.contains("hiddenreplytree")) {
-        replyTree.classList.replace("hiddenreplytree", "visiblereplytree");
-        toggleButton.innerText = "unfold_less";
-      } else {
-        replyTree.classList.replace("visiblereplytree", "hiddenreplytree");
-        toggleButton.innerText = "unfold_more";
-      }
-    }
+    const toggleButton = createToggleButton();
     thisReply.appendChild(toggleButton);
     thisReply.appendChild(replyTree);
     return thisReply;
+  }
+}
+
+// Return button that toggles reply trees in and out
+function createToggleButton() {
+  const toggleButton = document.createElement("button");
+  toggleButton.classList.add("material-icons", "togglereply");
+  toggleButton.innerText = "unfold_less";
+  toggleButton.onclick = () => {
+    if (replyTree.classList.contains("hiddenreplytree")) {
+      replyTree.classList.replace("hiddenreplytree", "visiblereplytree");
+      toggleButton.innerText = "unfold_less";
+    } else {
+      replyTree.classList.replace("visiblereplytree", "hiddenreplytree");
+      toggleButton.innerText = "unfold_more";
+    }
   }
 }
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -126,13 +126,17 @@ function startSlideshow() {
 function loadComments() {
   const maxcomments = document.getElementById("numcomments").value;
   const sortMetric = document.getElementById("sortby").value;
+  const filterMetric = document.getElementById("filterby").value;
+  const filterText = document.getElementById("filtertext").value;
+
   let sortOrder = "";
   if (document.getElementById("sortorder").classList.contains("desc")) {
     sortOrder = "desc";
   } else {
     sortOrder = "asc";
   }
-  const fetchString = `/data?maxcomments=${maxcomments}&metric=${sortMetric}&order=${sortOrder}`;
+  let fetchString = `/data?maxcomments=${maxcomments}&metric=${sortMetric}&order=${sortOrder}`;
+  fetchString = fetchString + `&filterby=${filterMetric}&filtertext=${filterText}`;
   fetch(fetchString).then(response => response.json()).then(comments => {
     const commentList = document.getElementById("toplevelcomments");
     while (commentList.lastChild) {
@@ -182,13 +186,26 @@ function constructReplyTree(comment, commentTree, margin) {
   } else {
     let thisReply = createListElement(comment);
     let replyTree = document.createElement("ul");
-    replyTree.className = "comments";
+    replyTree.classList.add("comments", "visiblereplytree");
     const newMargin = margin + 20;
     for (const child of children) {
       const subTree = constructReplyTree(child, commentTree, newMargin);
       replyTree.appendChild(subTree);
     }
     replyTree.style.marginLeft = `${margin}px`;
+    const toggleButton = document.createElement("button");
+    toggleButton.classList.add("material-icons", "togglereply");
+    toggleButton.innerText = "unfold_less";
+    toggleButton.onclick = () => {
+        if(replyTree.classList.contains("hiddenreplytree")) {
+            replyTree.classList.replace("hiddenreplytree", "visiblereplytree");
+            toggleButton.innerText = "unfold_less";
+        } else {
+            replyTree.classList.replace("visiblereplytree", "hiddenreplytree");
+            toggleButton.innerText = "unfold_more";
+        }
+    }
+    thisReply.appendChild(toggleButton);
     thisReply.appendChild(replyTree);
     return thisReply;
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -197,13 +197,13 @@ function constructReplyTree(comment, commentTree, margin) {
     toggleButton.classList.add("material-icons", "togglereply");
     toggleButton.innerText = "unfold_less";
     toggleButton.onclick = () => {
-        if(replyTree.classList.contains("hiddenreplytree")) {
-            replyTree.classList.replace("hiddenreplytree", "visiblereplytree");
-            toggleButton.innerText = "unfold_less";
-        } else {
-            replyTree.classList.replace("visiblereplytree", "hiddenreplytree");
-            toggleButton.innerText = "unfold_more";
-        }
+      if (replyTree.classList.contains("hiddenreplytree")) {
+        replyTree.classList.replace("hiddenreplytree", "visiblereplytree");
+        toggleButton.innerText = "unfold_less";
+      } else {
+        replyTree.classList.replace("visiblereplytree", "hiddenreplytree");
+        toggleButton.innerText = "unfold_more";
+      }
     }
     thisReply.appendChild(toggleButton);
     thisReply.appendChild(replyTree);

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -259,6 +259,12 @@ p {
   min-width: 350px;
 }
 
+.comments {
+  list-style-type: none;
+  margin-top: 20px;
+  border-left: 2px solid grey;
+}
+
 #toplevelcomments {
   height: 800px;
   overflow: auto;
@@ -267,11 +273,7 @@ p {
   padding-bottom: 20px;
   margin-left: 20px;
   margin-right:20px;
-}
-
-.comments {
-  list-style-type: none;
-  margin-top: 20px;
+  border: none;
 }
 
 .comment {
@@ -290,7 +292,9 @@ p {
 
 #sortorder {
   width: 40px;
-  height: 40px;
+  height: 30px;
+  display: table-cell;
+  vertical-align: middle;
 }
 
 .commentparam {
@@ -312,6 +316,40 @@ p {
 }
 
 .vote-buttons {
-    display: inline;
-    float: right;
+  display: inline;
+  float: right;
+}
+
+#filterby, #filtertext {
+  display: inline-block;
+  margin-left: 0px;
+  margin-right: 0px;
+  padding left: 0px;
+  padding-right: 0px;
+}
+
+#filtertext {
+  width: 85%;
+  height: 24px;
+}
+
+#filterdiv {
+  margin-left: 20px;
+}
+
+select, button, #submitform {
+  height: 30px;
+  font-family: 'Montserrat', sans-serif;
+}
+
+#commenthistory {
+  margin-top: 100px;
+}
+
+.hiddenreplytree {
+  display: none;
+}
+
+.visiblereplytree {
+  display: block;
 }


### PR DESCRIPTION
In this PR, I:
- added the ability to filter comments by the contents of name, email and comment fields
- added a button to toggle reply trees in and out 
![Screenshot 2020-06-05 at 4 00 48 PM](https://user-images.githubusercontent.com/22436066/83929295-ad494c00-a747-11ea-9b84-60aa5aadc4b8.png)
