### PR TITLE
Allow user to edit and delete their own comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -85,7 +85,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>isanturkar-step-2020</deploy.projectId>
+          <deploy.projectId>isanturkar-step-new-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -145,8 +145,8 @@ public class DataServlet extends HttpServlet {
             UserComment.voteStatus.DOWNVOTED;
     }
 
-    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId
-        , upvotes, downvotes, isEditable, votingStatus);
+    UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId,
+        upvotes, downvotes, isEditable, votingStatus);
     return userComment;
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -132,9 +132,11 @@ public class DataServlet extends HttpServlet {
     long upvotes = entity.getLong("upvotes");
     long downvotes = upvotes - entity.getLong("score");
     String voters = entity.getString("voters");
+    String commenterId = entity.getString("userid");
     
     JsonObject obj = UtilityFunctions.stringToJsonObject(voters);
     String userId = UtilityFunctions.getCurrentUserId();
+    boolean isEditable = commenterId.equals(userId);
     int currUserStatus = 0;
 
     if (obj.has(userId)) {
@@ -142,7 +144,7 @@ public class DataServlet extends HttpServlet {
     }
 
     UserComment userComment = UserComment.create(name, email, comment, time, id, parentId, rootId
-        , upvotes, downvotes, currUserStatus);
+        , upvotes, downvotes, isEditable, currUserStatus);
     return userComment;
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteAllServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteAllServlet.java
@@ -29,8 +29,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@WebServlet("/delete-data")
-public class DeleteServlet extends HttpServlet {
+@WebServlet("/delete-all")
+public class DeleteAllServlet extends HttpServlet {
 
   /*
    * Called when a client submits a POST request to the /delete-data URL,

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteOneServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteOneServlet.java
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.Entity;
+import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/delete-one")
+public class DeleteOneServlet extends HttpServlet {
+
+  /*
+   * Called when a POST request is submitted to /delete-one, deletes the 
+   * comment that was clicked as well as all of its replies
+   * Invariant: The comment must have been authored by the current user
+   */
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String parsedBody = CharStreams.toString(request.getReader());
+    JsonObject jsonObject = UtilityFunctions.stringToJsonObject(parsedBody);
+
+    long commentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
+        jsonObject, "id", "0"));
+
+    if (commentId != 0) {
+      deleteVoteInDatastore(commentId);
+    }
+  }
+
+  /* 
+   * Deletes comment represented by commentId from the datastore
+   */
+  private void deleteVoteInDatastore(long commentId) {
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+    KeyFactory keyFactory = datastore.newKeyFactory().setKind("Comment");
+    datastore.delete(keyFactory.newKey(commentId));
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/EditServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/EditServlet.java
@@ -32,13 +32,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@WebServlet("/delete-one")
-public class DeleteOneServlet extends HttpServlet {
+@WebServlet("/edit")
+public class EditServlet extends HttpServlet {
 
   /*
-   * Called when a POST request is submitted to /delete-one, deletes the 
-   * comment that was clicked as well as all of its replies
-   * Invariant: The comment must have been authored by the current user
+   * Called when a POST request is submitted to /edit, updates the comment
+   * that has been edited to reflect its new content
+   * Invariant: a user can only edit comments they authored
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -47,18 +47,21 @@ public class DeleteOneServlet extends HttpServlet {
 
     long commentId = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
         jsonObject, "id", "0"));
+    String newComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
 
-    if (commentId != 0) {
-      deleteInDatastore(commentId);
+    if (newComment.length() != 0) {
+      editInDatastore(commentId, newComment);
     }
   }
 
   /* 
    * Deletes comment represented by commentId from the datastore
    */
-  private void deleteInDatastore(long commentId) {
+  private void editInDatastore(long commentId, String newComment) {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     KeyFactory keyFactory = datastore.newKeyFactory().setKind("Comment");
-    datastore.delete(keyFactory.newKey(commentId));
+    Entity comment = datastore.get(keyFactory.newKey(commentId));
+    Entity updatedComment = Entity.newBuilder(comment).set("comment", newComment).build();
+    datastore.update(updatedComment);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ReplyServlet.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 package com.google.sps.servlets;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -34,14 +37,19 @@ public class ReplyServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    if (!userService.isUserLoggedIn()) {
+        return;
+    }
+
+    User currUser = userService.getCurrentUser();
     String parsedBody = CharStreams.toString(request.getReader());
     JsonObject jsonObject = UtilityFunctions.stringToJsonObject(parsedBody);
 
     String userComment = UtilityFunctions.getFieldFromJsonObject(jsonObject, "comment", "");
     if (userComment.length() != 0) {
       String userName = UtilityFunctions.getFieldFromJsonObject(jsonObject, "name", "Anonymous");
-      String userEmail = UtilityFunctions.getFieldFromJsonObject(
-          jsonObject, "email", "janedoe@gmail.com");
+      String userEmail = currUser != null ? currUser.getEmail() : "janedoe@gmail.com";
       String currDate = String.valueOf(System.currentTimeMillis());
       long userDate = Long.parseLong(UtilityFunctions.getFieldFromJsonObject(
           jsonObject, "timestamp", currDate));

--- a/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
@@ -37,8 +37,8 @@ abstract class UserComment {
       long downvotes,
       boolean isEditable, 
       voteStatus votingStatus) {
-    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId
-        , rootId, upvotes, downvotes, isEditable, votingStatus);
+    return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId,
+        rootId, upvotes, downvotes, isEditable, votingStatus);
   }
 
   /*

--- a/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserComment.java
@@ -28,9 +28,10 @@ abstract class UserComment {
       long rootId,
       long upvotes,
       long downvotes,
+      boolean isEditable, 
       long currUserStatus) {
     return new AutoValue_UserComment(name, email, comment, timestamp, id, parentId
-        , rootId, upvotes, downvotes, currUserStatus);
+        , rootId, upvotes, downvotes, isEditable, currUserStatus);
   }
 
   /*
@@ -103,6 +104,12 @@ abstract class UserComment {
    */
   abstract long downvotes();
 
+  /*
+   * Represents whether the current user is the author of this
+   * comment and can edit it
+   */
+  abstract boolean isEditable();
+  
   /*
    * Represents whether the current user has upvoted (1), downvoted
    * (-1) or not voted for (0) the given comment. 

--- a/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UtilityFunctions.java
@@ -71,6 +71,7 @@ public class UtilityFunctions {
           .set("upvotes", upvotes)
           .set("score", upvotes - downvotes)
           .set("voters", "{}")
+          .set("userid", getCurrentUserId())
           .build();
     datastore.add(thisComment);
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -249,9 +249,34 @@ function createListElement(comment) {
   formatCommentVoteButtons(comment, thisCommentDiv);
   thisCommentDiv.appendChild(quote);
   thisCommentDiv.appendChild(reply);
+  if(comment["isEditable"]) {
+    formatCommentDeleteButton(comment, thisCommentDiv);
+  }
   thisCommentDiv.className = "comment";
   listElem.appendChild(thisCommentDiv);
   return listElem;
+}
+
+function formatCommentDeleteButton(comment, thisDiv) {
+  const deleteButton = document.createElement("button");
+  deleteButton.className = "material-icons";
+  deleteButton.innerText = "delete";
+  deleteButton.onclick = () => deleteComment(comment);
+  thisDiv.appendChild(deleteButton);
+}
+
+function deleteComment(comment) {
+  const deleteObj = {};
+  deleteObj["id"] = comment["id"];
+  fetch('/delete-one', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(deleteObj),
+  }).then(response => {
+    loadComments();
+  });
 }
 
 /**
@@ -416,11 +441,11 @@ function submitForm(form) {
 }
 
 /**
- * Submits a post request to /delete-data to delete all comments,
+ * Submits a post request to /delete-all to delete all comments,
  * then reloads the comments section
  */
 function clearComments() {
-  fetch("/delete-data", {
+  fetch("/delete-all", {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -249,12 +249,68 @@ function createListElement(comment) {
   formatCommentVoteButtons(comment, thisCommentDiv);
   thisCommentDiv.appendChild(quote);
   thisCommentDiv.appendChild(reply);
-  if(comment["isEditable"]) {
+  if (comment["isEditable"]) {
+    formatCommentEditButton(comment, thisCommentDiv, quote);
     formatCommentDeleteButton(comment, thisCommentDiv);
   }
   thisCommentDiv.className = "comment";
   listElem.appendChild(thisCommentDiv);
   return listElem;
+}
+
+/**
+ * Appends a button which allows users to edit their comment when clicked
+ * onto commentDiv
+ */ 
+function formatCommentEditButton(comment, commentDiv, commentText) {
+  const editButton = document.createElement("button");
+  editButton.className = "material-icons";
+  editButton.innerText = "create";
+  editButton.onclick = () => editComment(comment, commentDiv, commentText);
+  commentDiv.appendChild(editButton);
+}
+
+/**
+ * Triggered when edit button of a comment is clicked, opens
+ * up a text area for user to format reply and a button which
+ * when clicked, submits the updated comment and reloads the
+ * page
+ */
+function editComment(comment, commentDiv, commentText) {
+  const editDiv = document.createElement("div");
+  editDiv.className = "editdiv";
+  const editBar = document.createElement("textarea");
+  editBar.innerText = commentText.innerText;
+  editBar.className = "editbar";
+  const editSubmit = document.createElement("button");
+  editSubmit.innerText = "Submit"
+  editSubmit.className = "editbutton";
+  editSubmit.onclick = () => modifyComment(comment, editBar.value);
+  editDiv.appendChild(editBar);
+  editDiv.appendChild(editSubmit);
+  while (commentDiv.firstChild) {
+    commentDiv.removeChild(commentDiv.firstChild);
+  }
+  commentDiv.appendChild(editDiv);
+}
+
+/**
+ * Submits the modified comment with content represented
+ * by newContent to the server and reloads the page
+ */
+function modifyComment(comment, newContent) {
+  const editObj = {};
+  editObj["id"] = comment["id"];
+  editObj["comment"] = newContent;
+  fetch('/edit', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(editObj),
+  }).then(response => {
+    loadComments();
+  });
 }
 
 function formatCommentDeleteButton(comment, thisDiv) {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -304,17 +304,25 @@ p {
   margin-right: 20px;
 }
 
-.replydiv {
+.replydiv, .editdiv {
   margin-left: 10px;
   margin-right: 20px;
 }
 
-.replybar {
+.replybar, .editbar {
   width: 80%;
 }
 
-.replybutton {
-  float:right;
+.editbar {
+  margin: 20px;
+}
+
+.replybutton, .editbutton {
+  float: right;
+}
+
+.editbutton {
+  margin: 20px;
 }
 
 .vote-buttons {


### PR DESCRIPTION
In this PR, I
- added a button that allows users to delete individual comments. This is only dispayed for the user's own comments.
- added a button that allows users to edit their comments. When clicked, a text area opens up that on submission, reloads the page with the updated text.
The page looks like this:
![Screenshot 2020-06-09 at 11 30 02 AM](https://user-images.githubusercontent.com/22436066/84186081-d2d69e00-aa44-11ea-8981-728e2bec0373.png)
