### PR TITLE
Add code to accommodate optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/pom.xml
+++ b/walkthroughs/week-5-tdd/project/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>19.0</version>
+        <version>24.1.1</version>
     </dependency>
 
 

--- a/walkthroughs/week-5-tdd/project/pom.xml
+++ b/walkthroughs/week-5-tdd/project/pom.xml
@@ -30,11 +30,13 @@
       <version>2.8.6</version>
     </dependency>
     
+    <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
     <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>24.1.1</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
     </dependency>
+
 
 
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -104,8 +104,7 @@ public final class FindMeetingQuery {
       if (i >= startPoint && i <= endPoint) {
         // Replace all the entries between startPoint and endPoint with the coalesced entry
         continue;
-      } 
-      else {
+      } else {
         newBusyTimes.add(busyTimes.get(i));
       }
     }
@@ -158,13 +157,12 @@ public final class FindMeetingQuery {
     HashSet<String> attendees = new HashSet<>(request.getAttendees());
     HashSet<String> optAttendees = new HashSet<>(request.getOptionalAttendees());
 
-
     Iterator<Event> iterator = events.iterator();
     while (iterator.hasNext()) {
       Event meeting = iterator.next();
       Set<String> meetingAttendees = meeting.getAttendees();
       if (Sets.intersection(attendees, meetingAttendees).isEmpty()) {
-        if(!Sets.intersection(optAttendees, meetingAttendees).isEmpty()) {
+        if (!Sets.intersection(optAttendees, meetingAttendees).isEmpty()) {
           optBusy = addToBusy(optBusy, meeting);
         }
       } else {
@@ -173,7 +171,7 @@ public final class FindMeetingQuery {
       }
     }
     ArrayList<TimeRange> optFree = findFreeTimes(optBusy, request.getDuration());
-    if(optFree.size() == 0 && attendees.size() != 0) {
+    if (optFree.size() == 0 && attendees.size() != 0) {
       return findFreeTimes(reqBusy, request.getDuration());
     }
     return optFree;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -153,6 +153,8 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     ArrayList<TimeRange> busy = new ArrayList<>();
     HashSet<String> attendees = new HashSet<>(request.getAttendees());
+    // HashSet<String> optAttendees = new HashSet<>(request.getOptionalAttendees());
+    // attendees.addAll(optAttendees);
     Iterator<Event> iterator = events.iterator();
     while (iterator.hasNext()) {
       Event meeting = iterator.next();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -41,7 +41,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
- 
+
   private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
@@ -156,8 +156,7 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 3",
                 TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
-                Arrays.asList(PERSON_C))
-            );
+                Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
@@ -175,7 +174,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void optionalAttendeeConsidered() {
     // Have the mandatory attendees have two different events. They split the day into
-    // three free time slots. The optional attendee is busy in one of them, so only the 
+    // three free time slots. The optional attendee is busy in one of them, so only the
     // other two should be returned.
     //
     // Mandatory Events  :       |--A--|     |--B--|
@@ -196,8 +195,7 @@ public final class FindMeetingQueryTest {
             new Event(
                 "Event 3",
                 TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
-                Arrays.asList(PERSON_C))
-            );
+                Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
@@ -338,9 +336,9 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void notEnoughRoomWithOptional() {
-    // Have one mandatory person, but make it so that there is just enough room at one point in 
+    // Have one mandatory person, but make it so that there is just enough room at one point in
     // the day to have the meeting. The optional attendee is busy during part of this time slot,
-    // and since the rest of it is too small to hold the meeting, the optional attendee's 
+    // and since the rest of it is too small to hold the meeting, the optional attendee's
     // constraint is ignored
     //
     // Events           : |--A--|       |----A----|
@@ -429,9 +427,10 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 
-@Test
+  @Test
   public void optionalAttendeesOnly() {
-    // All attendees are optional. Have each person have different events. We should see four options 
+    // All attendees are optional. Have each person have different events. We should see four
+    // options
     // because each person has split the restricted times.
     //
     // Events  :       |--A--|     |--B--|
@@ -449,8 +448,7 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
                 Arrays.asList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
@@ -471,7 +469,7 @@ public final class FindMeetingQueryTest {
     //
     // Events  : |--B--||--A--||-B-||-A-||--B--|
     // Day     : |-----------------------------|
-    // Options : 
+    // Options :
 
     Collection<Event> events =
         Arrays.asList(
@@ -496,14 +494,12 @@ public final class FindMeetingQueryTest {
                 TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
                 Arrays.asList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList();
+    Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -32,6 +32,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -40,7 +41,8 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
-
+ 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -125,6 +127,85 @@ public final class FindMeetingQueryTest {
         Arrays.asList(
             TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeNotRequired() {
+    // Have the mandatory attendees have two different events. The optional attendee
+    // is busy all day, so we should just see 3 options because each mandatory person has
+    // split the restricted times.
+    //
+    // Mandatory Events  :       |--A--|     |--B--|
+    // Optional Events   : |--------------C--------------|
+    // Day               : |-----------------------------|
+    // Options           : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_C))
+            );
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeConsidered() {
+    // Have the mandatory attendees have two different events. They split the day into
+    // three free time slots. The optional attendee is busy in one of them, so only the 
+    // other two should be returned.
+    //
+    // Mandatory Events  :       |--A--|     |--B--|
+    // Optional Events   :             |--C--|
+    // Day               : |-----------------------------|
+    // Options           : |--1--|                 |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_C))
+            );
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -256,6 +337,42 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void notEnoughRoomWithOptional() {
+    // Have one mandatory person, but make it so that there is just enough room at one point in 
+    // the day to have the meeting. The optional attendee is busy during part of this time slot,
+    // and since the rest of it is too small to hold the meeting, the optional attendee's 
+    // constraint is ignored
+    //
+    // Events           : |--A--|       |----A----|
+    // Optional Events  :       |-C-|
+    // Day              : |-----------------------|
+    // Options          :       |-------|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
@@ -308,6 +425,85 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+@Test
+  public void optionalAttendeesOnly() {
+    // All attendees are optional. Have each person have different events. We should see four options 
+    // because each person has split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesBusy() {
+    // All attendees are optional. Have each person have different events so that there
+    // are no free times. No times should be returned.
+    //
+    // Events  : |--B--||--A--||-B-||-A-||--B--|
+    // Day     : |-----------------------------|
+    // Options : 
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 4",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 5",
+                TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
In this PR, I:
- added code so that optional attendees schedules are considered. If everyone can make some timeslot, then all those are returned otherwise the timeslots that required attendees can make are returned.
- added tests to test this feature
The feature passes all test cases.